### PR TITLE
PolySub: really prevent cutoff from exceeding Nyquist freq

### DIFF
--- a/lib/Engine_PolySub.sc
+++ b/lib/Engine_PolySub.sc
@@ -60,7 +60,7 @@ Engine_PolySub : CroneEngine {
 				fenv = EnvGen.ar(Env.adsr(cutAtk, cutDec, cutSus, cutRel), gate);
 
 				cut = SelectX.kr(cutEnvAmt, [cut, cut * fenv]);
-				cut = cut * hz.min(SampleRate.ir * 0.5);
+				cut = (cut * hz).min(SampleRate.ir * 0.5 - 1);
 
 				snd = SelectX.ar(noise, [snd, [PinkNoise.ar, PinkNoise.ar]]);
 				snd = MoogFF.ar(snd, cut, fgain) * aenv;


### PR DESCRIPTION
Fixes #28. Just adds some parens and a `- 1`, to make sure the cutoff is always below Nyquist.